### PR TITLE
Simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,16 +41,30 @@ All parameters use SI units.
 
 ## Usage
 
-Currently this repository offers the `view_tracebot_mockup.launch` file, inside `tracebot_mockup_description` to visualize the mockup model using rviz.
+Currently this repository offers the `tracebot_mockup_simulator.launch` file, inside `tracebot_mockup_simulator` to start the simulated mockup model and visualize it using rviz.
 
 This launchfile exposes the parameters listed in [Model Parameters](#model-parameters) as arguments, providing reasonable defaults.
 For instance, to visualize the model with a 30 degree tilt of the robot bases, run:
 
 ```bash
-roslaunch tracebot_mockup_description view_tracebot_mockup.launch robot_base_tilt:=0.5236
+roslaunch tracebot_mockup_simulator tracebot_mockup_simulator.launch robot_base_tilt:=0.5236
 ```
 
-A camera view can be added to rviz:
+The suggested way to interact with this simulator at this point is to use `rqt_controller_manager` and `rqt_joint_trajectory_controller` to interact with the default controllers in the simulation.
+
+Alternatively, a simpler visualization can be started by launching a `joint_state_publisher_gui`-based setup with:
+
+```bash
+roslaunch tracebot_mockup_description view_tracebot_mockup.launch interactive:=true
+```
+
+The simple visualization allows the initial position of each of the joints to be configured using roslaunch arguments, such as:
+
+```bash
+roslaunch tracebot_mockup_description view_tracebot_mockup.launch interactive:=true left_shoulder_pan_position:=0.0
+```
+
+A camera view can be added to rviz when viewing either the simulator or the simple visualization with:
 
 ```bash
 roslaunch tracebot_mockup_description camera_display.launch

--- a/tracebot_mockup_description/launch/load_model.launch
+++ b/tracebot_mockup_description/launch/load_model.launch
@@ -1,0 +1,39 @@
+<launch>
+
+  <arg name="table_length" default="2.0"/>
+  <arg name="table_width" default="2.0"/>
+  <arg name="table_height" default="1.0"/>
+  <arg name="robot_mount_offset_x" default="0.0"/>
+  <arg name="robot_mount_offset_y" default="-0.2"/>
+  <arg name="robot_mount_offset_theta" default="0.0"/>
+  <arg name="robot_mount_length" default="0.2"/>
+  <arg name="robot_mount_width" default="0.2"/>
+  <arg name="robot_mount_height" default="0.6"/>
+  <arg name="robot_base_tilt" default="0.0"/>
+  <arg name="pump_offset_x" default="0.0"/>
+  <arg name="pump_offset_y" default="0.2"/>
+  <arg name="pump_offset_theta" default="0.0"/>
+  <arg name="pump_length" default="0.2"/>
+  <arg name="pump_width" default="0.3"/>
+  <arg name="pump_height" default="0.4"/>
+
+  <param name="robot_description" command="$(find xacro)/xacro $(find tracebot_mockup_description)/urdf/tracebot_mockup.urdf.xacro
+    table_length:=$(arg table_length)
+    table_width:=$(arg table_width)
+    table_height:=$(arg table_height)
+    robot_mount_offset_x:=$(arg robot_mount_offset_x)
+    robot_mount_offset_y:=$(arg robot_mount_offset_y)
+    robot_mount_offset_theta:=$(arg robot_mount_offset_theta)
+    robot_mount_length:=$(arg robot_mount_length)
+    robot_mount_width:=$(arg robot_mount_width)
+    robot_mount_height:=$(arg robot_mount_height)
+    robot_base_tilt:=$(arg robot_base_tilt)
+    pump_offset_x:=$(arg pump_offset_x)
+    pump_offset_y:=$(arg pump_offset_y)
+    pump_offset_theta:=$(arg pump_offset_theta)
+    pump_length:=$(arg pump_length)
+    pump_width:=$(arg pump_width)
+    pump_height:=$(arg pump_height)
+    "/>
+
+</launch>

--- a/tracebot_mockup_description/launch/view_tracebot_mockup.launch
+++ b/tracebot_mockup_description/launch/view_tracebot_mockup.launch
@@ -1,5 +1,7 @@
 <launch>
 
+  <arg name="interactive" default="false"/>
+
   <arg name="table_length" default="2.0"/>
   <arg name="table_width" default="2.0"/>
   <arg name="table_height" default="1.0"/>
@@ -17,26 +19,10 @@
   <arg name="pump_width" default="0.3"/>
   <arg name="pump_height" default="0.4"/>
 
-  <param name="robot_description" command="$(find xacro)/xacro $(find tracebot_mockup_description)/urdf/tracebot_mockup.urdf.xacro
-    table_length:=$(arg table_length)
-    table_width:=$(arg table_width)
-    table_height:=$(arg table_height)
-    robot_mount_offset_x:=$(arg robot_mount_offset_x)
-    robot_mount_offset_y:=$(arg robot_mount_offset_y)
-    robot_mount_offset_theta:=$(arg robot_mount_offset_theta)
-    robot_mount_length:=$(arg robot_mount_length)
-    robot_mount_width:=$(arg robot_mount_width)
-    robot_mount_height:=$(arg robot_mount_height)
-    robot_base_tilt:=$(arg robot_base_tilt)
-    pump_offset_x:=$(arg pump_offset_x)
-    pump_offset_y:=$(arg pump_offset_y)
-    pump_offset_theta:=$(arg pump_offset_theta)
-    pump_length:=$(arg pump_length)
-    pump_width:=$(arg pump_width)
-    pump_height:=$(arg pump_height)
-    "/>
+  <include file="$(find tracebot_mockup_description)/launch/load_model.launch" pass_all_args="True"/>
 
-  <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui"/>
+  <node if="$(arg interactive)" name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui"/>
+
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
   <node name="rviz" pkg="rviz" type="rviz" args="-d $(find tracebot_mockup_description)/config/tracebot_mockup.rviz"/>
 

--- a/tracebot_mockup_simulator/CMakeLists.txt
+++ b/tracebot_mockup_simulator/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(tracebot_mockup_simulator)
+
+find_package(catkin REQUIRED)
+
+catkin_package()
+
+if (CATKIN_ENABLE_TESTING)
+  find_package(roslaunch REQUIRED)
+  roslaunch_add_file_check(launch)
+endif()
+
+install(DIRECTORY config launch
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/
+)

--- a/tracebot_mockup_simulator/config/core_controllers.yaml
+++ b/tracebot_mockup_simulator/config/core_controllers.yaml
@@ -1,0 +1,129 @@
+joint_state_controller:
+  type:         joint_state_controller/JointStateController
+  publish_rate: 50
+
+joint_trajectory_controller:
+  type: velocity_controllers/JointTrajectoryController
+  joints:
+    - left_shoulder_pan_joint
+    - left_shoulder_lift_joint
+    - left_elbow_joint
+    - left_wrist_1_joint
+    - left_wrist_2_joint
+    - left_wrist_3_joint
+    - right_shoulder_pan_joint
+    - right_shoulder_lift_joint
+    - right_elbow_joint
+    - right_wrist_1_joint
+    - right_wrist_2_joint
+    - right_wrist_3_joint
+  constraints:
+    goal_time: &goal_time 5.0
+    left_shoulder_pan_joint: &joint_constraints
+      trajectory: 0.60
+      goal:       0.15
+    left_shoulder_lift_joint: *joint_constraints
+    left_elbow_joint: *joint_constraints
+    left_wrist_1_joint: *joint_constraints
+    left_wrist_2_joint: *joint_constraints
+    left_wrist_3_joint: *joint_constraints
+    right_shoulder_pan_joint: *joint_constraints
+    right_shoulder_lift_joint: *joint_constraints
+    right_elbow_joint: *joint_constraints
+    right_wrist_1_joint: *joint_constraints
+    right_wrist_2_joint: *joint_constraints
+    right_wrist_3_joint: *joint_constraints
+  gains:
+    left_shoulder_pan_joint: &joint_pid
+      p: 2.0
+      i: 0.0
+      d: 0.0
+      i_clamp: 1.0
+    left_shoulder_lift_joint: *joint_pid
+    left_elbow_joint: *joint_pid
+    left_wrist_1_joint: *joint_pid
+    left_wrist_2_joint: *joint_pid
+    left_wrist_3_joint: *joint_pid
+    right_shoulder_pan_joint: *joint_pid
+    right_shoulder_lift_joint: *joint_pid
+    right_elbow_joint: *joint_pid
+    right_wrist_1_joint: *joint_pid
+    right_wrist_2_joint: *joint_pid
+    right_wrist_3_joint: *joint_pid
+  velocity_ff:
+    left_shoulder_pan_joint: &joint_vel_ff 1.0
+    left_shoulder_lift_joint: *joint_vel_ff
+    left_elbow_joint: *joint_vel_ff
+    left_wrist_1_joint: *joint_vel_ff
+    left_wrist_2_joint: *joint_vel_ff
+    left_wrist_3_joint: *joint_vel_ff
+    right_shoulder_pan_joint: *joint_vel_ff
+    right_shoulder_lift_joint: *joint_vel_ff
+    right_elbow_joint: *joint_vel_ff
+    right_wrist_1_joint: *joint_vel_ff
+    right_wrist_2_joint: *joint_vel_ff
+    right_wrist_3_joint: *joint_vel_ff
+
+left_joint_trajectory_controller:
+  type: velocity_controllers/JointTrajectoryController
+  joints:
+    - left_shoulder_pan_joint
+    - left_shoulder_lift_joint
+    - left_elbow_joint
+    - left_wrist_1_joint
+    - left_wrist_2_joint
+    - left_wrist_3_joint
+  constraints:
+    goal_time: *goal_time
+    left_shoulder_pan_joint: *joint_constraints
+    left_shoulder_lift_joint: *joint_constraints
+    left_elbow_joint: *joint_constraints
+    left_wrist_1_joint: *joint_constraints
+    left_wrist_2_joint: *joint_constraints
+    left_wrist_3_joint: *joint_constraints
+  gains:
+    left_shoulder_pan_joint: *joint_pid
+    left_shoulder_lift_joint: *joint_pid
+    left_elbow_joint: *joint_pid
+    left_wrist_1_joint: *joint_pid
+    left_wrist_2_joint: *joint_pid
+    left_wrist_3_joint: *joint_pid
+  velocity_ff:
+    left_shoulder_pan_joint: *joint_vel_ff
+    left_shoulder_lift_joint: *joint_vel_ff
+    left_elbow_joint: *joint_vel_ff
+    left_wrist_1_joint: *joint_vel_ff
+    left_wrist_2_joint: *joint_vel_ff
+    left_wrist_3_joint: *joint_vel_ff
+
+right_joint_trajectory_controller:
+  type: velocity_controllers/JointTrajectoryController
+  joints:
+    - right_shoulder_pan_joint
+    - right_shoulder_lift_joint
+    - right_elbow_joint
+    - right_wrist_1_joint
+    - right_wrist_2_joint
+    - right_wrist_3_joint
+  constraints:
+    goal_time: *goal_time
+    right_shoulder_pan_joint: *joint_constraints
+    right_shoulder_lift_joint: *joint_constraints
+    right_elbow_joint: *joint_constraints
+    right_wrist_1_joint: *joint_constraints
+    right_wrist_2_joint: *joint_constraints
+    right_wrist_3_joint: *joint_constraints
+  gains:
+    right_shoulder_pan_joint: *joint_pid
+    right_shoulder_lift_joint: *joint_pid
+    right_elbow_joint: *joint_pid
+    right_wrist_1_joint: *joint_pid
+    right_wrist_2_joint: *joint_pid
+    right_wrist_3_joint: *joint_pid
+  velocity_ff:
+    right_shoulder_pan_joint: *joint_vel_ff
+    right_shoulder_lift_joint: *joint_vel_ff
+    right_elbow_joint: *joint_vel_ff
+    right_wrist_1_joint: *joint_vel_ff
+    right_wrist_2_joint: *joint_vel_ff
+    right_wrist_3_joint: *joint_vel_ff

--- a/tracebot_mockup_simulator/config/tracebot_mockup_hardware.yaml
+++ b/tracebot_mockup_simulator/config/tracebot_mockup_hardware.yaml
@@ -1,0 +1,34 @@
+combined_hardware_interface:
+  robot_hardware:
+    - left_ur_hw
+    - right_ur_hw
+
+  left_ur_hw:
+    type: ros_control_boilerplate/SimHWInterface
+    joints: &left_robot_joints
+      - left_shoulder_pan_joint
+      - left_shoulder_lift_joint
+      - left_elbow_joint
+      - left_wrist_1_joint
+      - left_wrist_2_joint
+      - left_wrist_3_joint
+    hardware_interface:
+      joints: *left_robot_joints
+      sim_control_mode: 1      # 0: position, 1: velocity
+
+  right_ur_hw:
+    type: ros_control_boilerplate/SimHWInterface
+    joints: &right_robot_joints
+      - right_shoulder_pan_joint
+      - right_shoulder_lift_joint
+      - right_elbow_joint
+      - right_wrist_1_joint
+      - right_wrist_2_joint
+      - right_wrist_3_joint
+    hardware_interface:
+      joints: *right_robot_joints
+      sim_control_mode: 1      # 0: position, 1: velocity
+
+generic_hw_control_loop:
+  loop_hz: 500
+  cycle_time_error_threshold: 0.002

--- a/tracebot_mockup_simulator/launch/tracebot_mockup_simulator.launch
+++ b/tracebot_mockup_simulator/launch/tracebot_mockup_simulator.launch
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<launch>
+
+  <arg name="debug" default="false" />
+  <arg unless="$(arg debug)" name="launch_prefix" value="" />
+  <arg     if="$(arg debug)" name="launch_prefix" value="gdb --ex run --args" />
+
+  <arg name="table_length" default="2.0"/>
+  <arg name="table_width" default="2.0"/>
+  <arg name="table_height" default="1.0"/>
+  <arg name="robot_mount_offset_x" default="0.0"/>
+  <arg name="robot_mount_offset_y" default="-0.2"/>
+  <arg name="robot_mount_offset_theta" default="0.0"/>
+  <arg name="robot_mount_length" default="0.2"/>
+  <arg name="robot_mount_width" default="0.2"/>
+  <arg name="robot_mount_height" default="0.6"/>
+  <arg name="robot_base_tilt" default="0.0"/>
+  <arg name="pump_offset_x" default="0.0"/>
+  <arg name="pump_offset_y" default="0.2"/>
+  <arg name="pump_offset_theta" default="0.0"/>
+  <arg name="pump_length" default="0.2"/>
+  <arg name="pump_width" default="0.3"/>
+  <arg name="pump_height" default="0.4"/>
+
+  <include file="$(find tracebot_mockup_description)/launch/view_tracebot_mockup.launch" pass_all_args="True"/>
+
+  <group ns="tracebot">
+
+    <rosparam file="$(find tracebot_mockup_simulator)/config/tracebot_mockup_hardware.yaml" />
+
+    <node name="combined_hardware_interface" pkg="ros_control_boilerplate" type="rrbot_combined_hw_main" output="screen" launch-prefix="$(arg launch_prefix)"/>
+
+    <rosparam file="$(find tracebot_mockup_simulator)/config/core_controllers.yaml"/>
+
+    <node name="controller_spawner" pkg="controller_manager" type="controller_manager" args="spawn joint_state_controller" />
+    <node name="controller_loader" pkg="controller_manager" type="controller_manager" args="load joint_trajectory_controller left_joint_trajectory_controller right_joint_trajectory_controller" />
+
+  </group>
+
+  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
+    <rosparam param="source_list">[/tracebot/joint_states]</rosparam>
+  </node>
+
+</launch>

--- a/tracebot_mockup_simulator/package.xml
+++ b/tracebot_mockup_simulator/package.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>tracebot_mockup_simulator</name>
+  <version>0.0.0</version>
+  <description>The tracebot_mockup_simulator package</description>
+
+  <maintainer email="miguel.prada@tecnalia.com">Miguel Prada</maintainer>
+
+  <license>TODO</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <exec_depend>controller_manager</exec_depend>
+  <exec_depend>joint_state_controller</exec_depend>
+  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>joint_trajectory_controller</exec_depend>
+  <exec_depend>ros_control_boilerplate</exec_depend>
+  <exec_depend>tracebot_mockup_description</exec_depend>
+  <exec_depend>xacro</exec_depend>
+
+  <test_depend>roslaunch</test_depend>
+
+  <export>
+  </export>
+</package>

--- a/upstream.repos
+++ b/upstream.repos
@@ -1,4 +1,8 @@
 repositories:
+  ros_control_boilerplate:
+    type: git
+    url: https://github.com/RobertWilbrandt/ros_control_boilerplate.git
+    version: noetic-devel_combined_robot_hw
   universal_robot:
     type: git
     url: https://github.com/ros-industrial/universal_robot.git


### PR DESCRIPTION
Adds a `ros_control`-based simulator (using `ros_control_boilerplate`) in `tracebot_mockup_simulator` package. Updated usage instructions are added to the README.